### PR TITLE
add double load click

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -543,10 +543,13 @@ typedef struct {
 	int numReliableCmds;
 	int thresholdTime;
 
+	// enable double load click to reset time in vet
+        long lastLoadTime;
+  
 	// Nico, save/load
 	save_position_t alliesSaves[MAX_SAVED_POSITIONS];
 	save_position_t axisSaves[MAX_SAVED_POSITIONS];
-
+	
 	// Nico, was it a selfkill last time you died?
 	qboolean lastDieWasASelfkill;
 


### PR DESCRIPTION
Sometimes you don't want to use strictSave, you want to be able to save and load while your timerun is active.
In this case, to reset your timerun, you needed to "/kill" yourself and you needed to "/load" again to jump to your previous position (so minimum 2 commands/binded buttons needed for that).

With this commit you can use your "/load" to reset your time while a timerun is active by just double-clicking it.
