### PR TITLE
Pronebug / Wallbug fix

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -64,6 +64,10 @@ If you have questions concerning this license or the applicable additional terms
 // Nico, spectator speed
 #define SPECTATOR_SPEED     1000
 
+// suburb, prevent pronebug & wallbug 
+#define MAX_BUGGING_SPEED         400
+#define BUGGING_CHECK_FREQUENCY   500
+
 #define FORCE_LIMBO_HEALTH  -75  // JPW NERVE
 
 #define GIB_HEALTH          -175  // JPW NERVE

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -958,7 +958,7 @@ void ClientThink_real(gentity_t *ent) {
 		SetTeam(ent, "s", -1, -1, qfalse);
 	}
 
-  // suburb, force snapping hud 0 in cup mode
+	// suburb, force snapping hud 0 in cup mode
 	if (g_cupMode.integer != 0 && client->pers.snapping != 0) {
 		CP(va("cpm \"%s^w: ^1You were removed from teams because you must use cg_drawVelocitySnapping 0.\n\"", GAME_VERSION_COLORED));
 		trap_SendServerCommand(ent - g_entities, "SnappingOff");

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -990,6 +990,7 @@ void ClientThink_real(gentity_t *ent) {
 			client->pers.oldPosition[i] = (int) pm.ps->origin[i];
 			client->pers.lastBuggingCheck = level.time;
 		}
+	}
 }
 
 /*

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -667,6 +667,9 @@ typedef struct {
 	// suburb, noclip speed scale
 	int noclipSpeed;
 
+	// suburb, prevent pronebug & wallbug
+	vec3_t oldPosition;
+	int lastBuggingCheck;
 } clientPersistant_t;
 
 typedef struct {


### PR DESCRIPTION
Prevent prone- and wallbug by killing the player if having speed > 400 ups, and not moving before starting a run

Fixes #35