### PR TITLE
Maprestart

### DIFF
--- a/etrun/ui/ingame_vote_misc.menu
+++ b/etrun/ui/ingame_vote_misc.menu
@@ -33,8 +33,9 @@ menuDef {
 // Buttons //
 
 	BUTTONEXT( 6, 32, (WINDOW_WIDTH-18), 14, "RANDOM MAP", .24, 11, exec "cmd callvote randommap"; uiScript closeingame, voteFlag CV_SVF_RANDOMMAP )
-	BUTTONEXT( 6, 50, (WINDOW_WIDTH-18), 14, "ANTI-LAG ON", .24, 11, exec "cmd callvote antilag 1"; uiScript closeingame, settingDisabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
-	BUTTONEXT( 6, 50, (WINDOW_WIDTH-18), 14, "ANTI-LAG OFF", .24, 11, exec "cmd callvote antilag 0"; uiScript closeingame, settingEnabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
+	BUTTONEXT( 6, 50, (WINDOW_WIDTH-18), 14, "MAP RESTART", .24, 11, exec "cmd callvote maprestart"; uiScript closeingame, voteFlag CV_SVF_MAPRESTART )
+	BUTTONEXT( 6, 68, (WINDOW_WIDTH-18), 14, "ANTI-LAG ON", .24, 11, exec "cmd callvote antilag 1"; uiScript closeingame, settingDisabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
+	BUTTONEXT( 6, 68, (WINDOW_WIDTH-18), 14, "ANTI-LAG OFF", .24, 11, exec "cmd callvote antilag 0"; uiScript closeingame, settingEnabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
 
 	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, "BACK", .3, 14, close ingame_vote_misc ; open ingame_vote )
 }

--- a/etrun/ui/menudef.h
+++ b/etrun/ui/menudef.h
@@ -406,9 +406,10 @@ If you have questions concerning this license or the applicable additional terms
 #define CV_SVF_KICK             1
 #define CV_SVF_MAP              2
 #define CV_SVF_RANDOMMAP        4
-#define CV_SVF_REFEREE          8
-#define CV_SVF_ANTILAG          16
-#define CV_SVF_MUTING           32
+#define CV_SVF_MAPRESTART       8
+#define CV_SVF_REFEREE          16
+#define CV_SVF_ANTILAG          32
+#define CV_SVF_MUTING           64
 
 // referee level
 #define RL_NONE                 0

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1787,6 +1787,7 @@ void G_delay_map_change(char *mapName, int delay); // Nico, function to delay a 
 void *G_delayed_map_change_watcher(void *arg); // Nico, thread used to check map changes
 int G_Map_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);
 int G_Randommap_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);
+int G_MapRestart_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);
 int G_Referee_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);
 int G_Unreferee_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);
 int G_AntiLag_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd);

--- a/src/game/g_vote.c
+++ b/src/game/g_vote.c
@@ -53,15 +53,16 @@ typedef struct {
 // VC optimizes for dup strings :)
 static const vote_reference_t aVoteInfo[] =
 {
-	{ "kick",      G_Kick_v,      "KICK",            " <player_id>^7\n  Attempts to kick player from server"             },
-	{ "mute",      G_Mute_v,      "MUTE",            " <player_id>^7\n  Removes the chat capabilities of a player"       },
-	{ "unmute",    G_UnMute_v,    "UN-MUTE",         " <player_id>^7\n  Restores the chat capabilities of a player"      },
-	{ "map",       G_Map_v,       "Change map to",   " <mapname>^7\n  Votes for a new map to be loaded"                  },
-	{ "randommap", G_Randommap_v, "Load Random Map", "^7\n  Loads a random map"                                          },
-	{ "referee",   G_Referee_v,   "Referee",         " <player_id>^7\n  Elects a player to have admin abilities"         },
-	{ "unreferee", G_Unreferee_v, "UNReferee",       " <player_id>^7\n  Elects a player to have admin abilities removed" },
-	{ "antilag",   G_AntiLag_v,   "Anti-Lag",        " <0|1>^7\n  Toggles Anit-Lag on the server"                        },
-	{ 0,           NULL,          0,                 NULL                                                                }
+	{ "kick",       G_Kick_v,       "KICK",            " <player_id>^7\n  Attempts to kick player from server"             },
+	{ "mute",       G_Mute_v,       "MUTE",            " <player_id>^7\n  Removes the chat capabilities of a player"       },
+	{ "unmute",     G_UnMute_v,     "UN-MUTE",         " <player_id>^7\n  Restores the chat capabilities of a player"      },
+	{ "map",        G_Map_v,        "Change map to",   " <mapname>^7\n  Votes for a new map to be loaded"                  },
+	{ "randommap",  G_Randommap_v,  "Load Random Map", "^7\n  Loads a random map"                                          },
+	{ "maprestart", G_MapRestart_v, "Map Restart",     "^7\n  Restarts the current map in progress"                        },
+	{ "referee",    G_Referee_v,    "Referee",         " <player_id>^7\n  Elects a player to have admin abilities"         },
+	{ "unreferee",  G_Unreferee_v,  "UNReferee",       " <player_id>^7\n  Elects a player to have admin abilities removed" },
+	{ "antilag",    G_AntiLag_v,    "Anti-Lag",        " <0|1>^7\n  Toggles Anit-Lag on the server"                        },
+	{ 0,            NULL,           0,                 NULL                                                                }
 };
 
 // Checks for valid custom callvote requests from the client.
@@ -510,6 +511,33 @@ int G_Randommap_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg
 		}
 	}
 	return G_OK;
+}
+
+// *** Map Restart ***
+int G_MapRestart_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2, qboolean fRefereeCmd) {
+	char serverinfo[MAX_INFO_STRING];
+	trap_GetServerinfo(serverinfo, sizeof(serverinfo));
+
+	// Vote request (vote is being initiated)
+	if (arg) {
+		// suburb, if map voting disabled, also disable maprestart
+		if (!vote_allow_map.integer && ent && !ent->client->sess.referee) {
+			G_voteDisableMessage(ent, arg);
+			G_voteCurrentSetting(ent, arg, Info_ValueForKey(serverinfo, "mapname"));
+			return G_INVALID;
+		}
+
+		if (trap_Argc() > 2) {
+			if (!Q_stricmp(arg2, "?")) {
+				G_refPrintf(ent, "Usage: ^3%s %s%s\n", ((fRefereeCmd) ? "\\ref" : "\\callvote"), arg, aVoteInfo[dwVoteIndex].pszVoteHelp);
+				return(G_INVALID);
+			}
+		}
+	} else {
+		// Restart the map
+		G_delay_map_change(Info_ValueForKey(serverinfo, "mapname"), 0);
+	}
+	return(G_OK);
 }
 
 // *** Referee voting ***


### PR DESCRIPTION
Bring it back because sometimes you want to restart the map if you e.g. moved a truck or opened a door which can take effect on timeruns.

`callvote map (current mapname)` also works, but like this you won't need to always write down the map's name 