### PR TITLE
Lock yaw- and pitchspeed

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1704,7 +1704,10 @@ extern vmCvar_t demo_infoWindow;
 // engine mappings
 extern vmCvar_t int_cl_maxpackets;
 extern vmCvar_t int_cl_timenudge;
-// -OSP
+
+// suburb, yawspeed & pitchspeed
+extern vmCvar_t int_cl_yawspeed;
+extern vmCvar_t int_cl_pitchspeed;
 
 extern vmCvar_t cg_rconPassword;
 extern vmCvar_t cg_refereePassword;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -221,6 +221,8 @@ vmCvar_t demo_drawTimeScale;
 vmCvar_t demo_infoWindow;
 vmCvar_t int_cl_maxpackets;
 vmCvar_t int_cl_timenudge;
+vmCvar_t int_cl_yawspeed;
+vmCvar_t int_cl_pitchspeed;
 vmCvar_t int_timescale;
 vmCvar_t cg_rconPassword;
 vmCvar_t cg_refereePassword;
@@ -477,7 +479,10 @@ cvarTable_t cvarTable[] =
 	// Engine mappings
 	{ &int_cl_maxpackets,       "cl_maxpackets",           "30",    CVAR_ARCHIVE,             0 },
 	{ &int_cl_timenudge,        "cl_timenudge",            "0",     CVAR_ARCHIVE,             0 },
-	// -OSP
+	
+	// suburb, yawspeed & pitchspeed
+	{ &int_cl_yawspeed,         "cl_yawspeed",             "140",   CVAR_ARCHIVE,             0 },
+	{ &int_cl_pitchspeed,       "cl_pitchspeed",           "140",   CVAR_ARCHIVE,             0 },
 
 	{ &cg_atmosphericEffects,   "cg_atmosphericEffects",   "1",     CVAR_ARCHIVE,             0 },
 	{ &authLevel,               "authLevel",               "0",     CVAR_TEMP | CVAR_ROM,     0 },
@@ -671,7 +676,8 @@ void CG_UpdateCvars(void) {
 				    cv->vmCvar == &cg_drawCGaz || cv->vmCvar == &cg_hideMe ||
 				    cv->vmCvar == &cg_autoDemo || cv->vmCvar == &cg_autoLoadCheckpoints ||
 				    cv->vmCvar == &cg_specLock || cv->vmCvar == &cg_keepAllDemos ||
-				    cv->vmCvar == &cg_loadWeapon || cv->vmCvar == &cg_noclipSpeed) {
+				    cv->vmCvar == &cg_loadWeapon || cv->vmCvar == &cg_noclipSpeed ||
+				    cv->vmCvar == &int_cl_yawspeed || cv->vmCvar == &int_cl_pitchspeed) {
 					fSetFlags = qtrue;
 				} else if (cv->vmCvar == &cg_crosshairColor || cv->vmCvar == &cg_crosshairAlpha) {
 					BG_setCrosshair(cg_crosshairColor.string, cg.xhairColor, cg_crosshairAlpha.value, "cg_crosshairColor");
@@ -744,7 +750,7 @@ void CG_setClientFlags(void) {
 	}
 
 	cg.pmext.bAutoReload = (cg_autoReload.integer > 0);
-	trap_Cvar_Set("cg_uinfo", va("%d %d %d %d %s %d %d %d %d %d %d %d %d %d %d",
+	trap_Cvar_Set("cg_uinfo", va("%d %d %d %d %s %d %d %d %d %d %d %d %d %d %d %d %d",
 	                             // Client Flags
 								 (
 									 ((cg_autoReload.integer > 0) ? CGF_AUTORELOAD : 0) |
@@ -795,7 +801,13 @@ void CG_setClientFlags(void) {
 	                             cg_keepAllDemos.integer,
 
 	                             // suburb, noclip speed scale
-	                             cg_noclipSpeed.integer
+	                             cg_noclipSpeed.integer,
+
+	                             // suburb, yawspeed
+	                             int_cl_yawspeed.integer,
+
+	                             // suburb, pitchspeed
+	                             int_cl_pitchspeed.integer
 	                             ));
 }
 

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1530,70 +1530,84 @@ static void CG_ServerCommand(void) {
 	// Nico, pmove_fixed
 	if (!Q_stricmp(cmd, "pmoveon")) {
 		trap_SendConsoleCommand("set pmove_fixed 1\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: pmove_fixed has been set to 1\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: pmove_fixed has been set to 1.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force max FPS
 	if (!Q_stricmp(cmd, "resetMaxFPS")) {
 		trap_SendConsoleCommand("set com_maxfps 125\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: com_maxfps has been set to 125\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: com_maxfps has been set to 125.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force max packets
 	if (!Q_stricmp(cmd, "resetMaxPackets")) {
 		trap_SendConsoleCommand("set cl_maxpackets 100\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_maxpackets has been set to 100\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_maxpackets has been set to 100.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force timernudge
 	if (!Q_stricmp(cmd, "resetTimeNudge")) {
 		trap_SendConsoleCommand("set cl_timenudge 0\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_timenudge has been set to 0\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_timenudge has been set to 0.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force rate
 	if (!Q_stricmp(cmd, "resetRate")) {
 		trap_SendConsoleCommand("set rate 25000\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: rate has been set to 25000\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: rate has been set to 25000.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force snaps
 	if (!Q_stricmp(cmd, "resetSnaps")) {
 		trap_SendConsoleCommand("set snaps 0\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: snaps has been set to 0\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: snaps has been set to 0.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		return;
+	}
+
+	// suburb, force yawspeed 0
+	if (!Q_stricmp(cmd, "resetYawspeed")) {
+		trap_SendConsoleCommand("set cl_yawspeed 0\n");
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_yawspeed has been set to 0.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		return;
+	}
+
+	// suburb, force pitchspeed 0
+	if (!Q_stricmp(cmd, "resetPitchspeed")) {
+		trap_SendConsoleCommand("set cl_pitchspeed 0\n");
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cl_pitchspeed has been set to 0.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force auto demo record
 	if (!Q_stricmp(cmd, "autoDemoOn")) {
 		trap_SendConsoleCommand("set cg_autoDemo 1\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_autoDemo has been set to 1\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_autoDemo has been set to 1.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force hideMe ON
 	if (!Q_stricmp(cmd, "hideMeOn")) {
 		trap_SendConsoleCommand("set cg_hideMe 1\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_hideMe has been set to 1\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_hideMe has been set to 1.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, force CGaz off
 	if (!Q_stricmp(cmd, "CGazOff")) {
 		trap_SendConsoleCommand("set cg_drawCGaz 0\n");
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_drawCGaz has been set to 0\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_drawCGaz has been set to 0.\n", GAME_VERSION_COLORED), cgs.media.voiceChatShader);
 		return;
 	}
 
 	// Nico, update specLock
 	if (!Q_stricmp(cmd, "updateSpecLockStatus")) {
 		trap_SendConsoleCommand(va("set cg_specLock %d\n", atoi(CG_Argv(1))));
-		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_specLock has been set to %d\n", GAME_VERSION_COLORED, atoi(CG_Argv(1))), cgs.media.voiceChatShader);
+		CG_AddPMItem(PM_MESSAGE, va("%s^w: cg_specLock has been set to %d.\n", GAME_VERSION_COLORED, atoi(CG_Argv(1))), cgs.media.voiceChatShader);
 		return;
 	}
 

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -897,6 +897,20 @@ void ClientThink_real(gentity_t *ent) {
 		SetTeam(ent, "s", -1, -1, qfalse);
 	}
 
+	// suburb, force yawspeed 0
+	if (client->pers.yawspeed != 0) {
+		CP(va("cpm \"%s^w: ^1You were removed from teams because you must use cl_yawspeed 0.\n\"", GAME_VERSION_COLORED));
+		trap_SendServerCommand(ent - g_entities, "resetYawspeed");
+		SetTeam(ent, "s", -1, -1, qfalse);
+	}
+
+	// suburb, force pitchspeed 0
+	if (client->pers.pitchspeed != 0) {
+		CP(va("cpm \"%s^w: ^1You were removed from teams because you must use cl_pitchspeed 0.\n\"", GAME_VERSION_COLORED));
+		trap_SendServerCommand(ent - g_entities, "resetPitchspeed");
+		SetTeam(ent, "s", -1, -1, qfalse);
+	}
+
 	// Nico, force auto demo record in cup mode
 	if (g_cupMode.integer != 0 && client->pers.autoDemo == 0) {
 		CP(va("cpm \"%s^w: ^1you were removed from teams because you must use cg_autoDemo 1\n\"", GAME_VERSION_COLORED));

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -887,7 +887,7 @@ void ClientUserinfoChanged(int clientNum) {
 	Q_strncpyz(oldAuthToken, client->pers.authToken, sizeof (oldAuthToken));
 
 	s = Info_ValueForKey(userinfo, "cg_uinfo");
-	sscanf(s, "%10u %3u %3u %3i %64s %1i %1i %1i %1i %1i %1i %1i %1i %1i %d",
+	sscanf(s, "%10u %3u %3u %3i %64s %1i %1i %1i %1i %1i %1i %1i %1i %1i %d %d %d",
 	       &client->pers.clientFlags,
 	       &client->pers.clientTimeNudge,
 	       &client->pers.clientMaxPackets,
@@ -926,7 +926,13 @@ void ClientUserinfoChanged(int clientNum) {
 	       &client->pers.keepAllDemos,
 
 	       // suburb, noclip speed scale
-	       &client->pers.noclipSpeed
+	       &client->pers.noclipSpeed,
+
+	       // suburb, yawspeed
+	       &client->pers.yawspeed,
+
+	       // suburb, pitchspeed
+	       &client->pers.pitchspeed
 	       );
 
 	// Nico, check if auth token was changed

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -667,6 +667,11 @@ typedef struct {
 	// suburb, noclip speed scale
 	int noclipSpeed;
 
+	// suburb, yawspeed
+	int yawspeed;
+
+	// suburb, pitchspeed
+	int pitchspeed;
 } clientPersistant_t;
 
 typedef struct {


### PR DESCRIPTION
Lock `cl_yawspeed` and `cl_pitchspeed` to 0 to prevent cheating / scripting with mostly +left and +right