### PR TITLE
Mod info printout & va fix

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -809,4 +809,7 @@ void CG_InitConsoleCommands(void) {
 
 	// suburb, tutorial
 	trap_AddCommand("tutorial");
+
+	// suburb, mod info
+	trap_AddCommand("mod_information");
 }

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -47,7 +47,10 @@ If you have questions concerning this license or the applicable additional terms
 #define MOD_URL                "http://www.timeruns.net"
 #define SHORT_MOD_URL          "www.timeruns.net"
 
-#define GAME_VERSION_DATED     GAME_VERSION "_"MOD_VERSION
+#define GAME_VERSION_DATED     GAME_VERSION "_" MOD_VERSION
+
+// suburb, build time if ever needed
+#define BUILD_TIME __DATE__ " " __TIME__
 
 //bani
 #ifdef __GNUC__

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2332,6 +2332,9 @@ void ClientCommand(int clientNum) {
 		Cmd_FollowCycle_f(ent, 1);
 	} else if (!Q_stricmp(cmd, "followprev")) {
 		Cmd_FollowCycle_f(ent, -1);
+	} else if (!Q_stricmp(cmd, "mod_information")) { // suburb, added mod info printout
+		CP(va("print \"%s %s\n\"", GAME_VERSION " " MOD_VERSION, BUILD_TIME));
+		return;
 	}
 
 	// Nico, flood protection

--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -58,7 +58,7 @@ void G_loadMatchGame(void) {
 void G_printFull(char *str, gentity_t *ent) {
 	if (ent != NULL) {
 		CP(va("print \"%s\n\"", str));
-		CP(va("cp \"%s\n\"", str));    // #fixme, prints "cp" :o
+		CP(va("cp \"%s\n\"", str));
 	} else {
 		AP(va("print \"%s\n\"", str));
 		AP(va("cp \"%s\n\"", str));

--- a/src/game/q_shared.c
+++ b/src/game/q_shared.c
@@ -666,7 +666,7 @@ char *QDECL va(const char *format, ...) {
 	size_t        len;
 
 	va_start(argptr, format);
-	vsprintf(temp_buffer, format, argptr); // Q_vsnprintf ???
+	Q_vsnprintf(temp_buffer, sizeof (temp_buffer), format, argptr);
 	va_end(argptr);
 
 	if ((len = strlen(temp_buffer)) >= MAX_VA_STRING) {

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -161,6 +161,7 @@ typedef int clipHandle_t;
 
 #define MAX_SAY_TEXT        150
 
+#define MAX_VA_STRING       32000
 typedef enum {
 	MESSAGE_EMPTY = 0,
 	MESSAGE_WAITING,        // rate/packet limited
@@ -576,7 +577,7 @@ int Q_vsnprintf(char *str, size_t size, const char *format, va_list ap);
 
 //=============================================
 
-char *QDECL va(char *format, ...) _attribute((format(printf, 1, 2)));
+char *QDECL va(const char *format, ...) _attribute((format(printf, 1, 2)));
 float *tv(float x, float y, float z);
 
 //=============================================


### PR DESCRIPTION
- Added mod info printout `cmd mod_information`
- Fixed `va()` function not working correctly in recursive calls, was causing "cp" printout if using the `va()` function inside the `G_printFull()` function