### PR TITLE
Spectatorstate

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2144,7 +2144,11 @@ static void CG_Draw2D(void) {
 		// Nico, draw info panel
 		CG_DrawInfoPanel();
 
+		// Nico, draw spectator message
 		CG_DrawSpectatorMessage();
+
+		// suburb, draw spectator state
+		CG_DrawSpectatorState();
 	} else {
 		if ((int)cgs.eventHandling != (int)CGAME_EVENT_NONE) {
 			trap_R_SetColor(NULL);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2019,6 +2019,7 @@ void CG_DrawKeys(void);
 void CG_DrawScoresClock(float x, float y, float scale);
 void CG_DrawBannerPrint(void);
 void CG_DrawInfoPanel(void);
+void CG_DrawSpectatorState(void);
 void CG_UpdateJumpSpeeds(void);
 void CG_UpdateKeysAndMenus(void);
 

--- a/src/cgame/cg_timerun_draw.c
+++ b/src/cgame/cg_timerun_draw.c
@@ -1100,3 +1100,35 @@ void CG_DrawInfoPanel(void) {
 		}
 	}
 }
+
+/*
+=================
+CG_DrawSpectatorState
+
+Draws text on hud if noclipping / in free spectator
+
+@author suburb
+=================
+*/
+void CG_DrawSpectatorState(void) {
+	char  *text = NULL;
+	float textScale;
+	int   x, y, w;
+
+	if (cg.predictedPlayerState.pm_type == PM_NOCLIP) {
+		text = "NOCLIP";
+	} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) {
+		text = "SPECTATOR";
+	} else {
+		return;
+	}
+
+	textScale = 0.3f;
+
+	x = CG_WideX(SCREEN_WIDTH) / 2;
+	y = SCREEN_HEIGHT / 6;
+
+	w = CG_Text_Width_Ext(text, textScale, textScale, &cgs.media.limboFont1) / 2;
+
+	CG_Text_Paint_Ext(x - w, y, textScale, textScale, colorWhite, text, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
+}

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -322,8 +322,6 @@ argv(0) noclip
 ==================
 */
 void Cmd_Noclip_f(gentity_t *ent) {
-	char *msg;
-
 	char *name = ConcatArgs(1);
 
 	// suburb, only available while unfollowed to avoid playermodel duplication
@@ -356,14 +354,6 @@ void Cmd_Noclip_f(gentity_t *ent) {
 	} else {
 		ent->client->noclip = !ent->client->noclip;
 	}
-
-	if (ent->client->noclip) {
-		msg = "noclip ON\n";
-	} else {
-		msg = "noclip OFF\n";
-	}
-
-	trap_SendServerCommand(ent - g_entities, va("print \"%s\"", msg));
 }
 
 /*


### PR DESCRIPTION
- Removed noclip ON/OFF console prints, were kind of flooding the console by always taking a new line
- Added `CG_DawSpectatorState` instead, prints a centered text on hud if in spec or while noclipping