### PR TITLE
Realigned disconnected pic

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -522,7 +522,7 @@ static void CG_DrawDisconnect(void) {
 		return;
 	}
 
-	x = CG_WideX(SCREEN_WIDTH) - 48;
+	x = CG_WideX(SCREEN_WIDTH) - 52;
 	y = SCREEN_HEIGHT - 200;
 
 	CG_DrawPic(x, y, 48, 48, cgs.media.disconnectIcon);


### PR DESCRIPTION
Moved lagometer 4 pixels to the left earlier, now the picture in `CG_DrawDisconnect` completely covers the lagometer again