### PR TITLE
CGaz 2 Borders fix

### DIFF
--- a/src/cgame/cg_timerun_draw.c
+++ b/src/cgame/cg_timerun_draw.c
@@ -575,6 +575,9 @@ void CG_DrawCGaz(void) {
 		CG_DrawLine(SCREEN_CENTER_X, SCREEN_CENTER_Y,
 		            SCREEN_CENTER_X + vel_size * sin(vel_relang),
 		            SCREEN_CENTER_Y - vel_size * cos(vel_relang), colorRed);
+		if (vel_size > SCREEN_HEIGHT / 2) {
+			vel_size = SCREEN_HEIGHT / 2;
+		}
 		vel_size /= 2;
 		CG_DrawLine(SCREEN_CENTER_X, SCREEN_CENTER_Y,
 		            SCREEN_CENTER_X + vel_size * sin(vel_relang + per_angle),

--- a/src/cgame/cg_timerun_draw.c
+++ b/src/cgame/cg_timerun_draw.c
@@ -569,12 +569,12 @@ void CG_DrawCGaz(void) {
 		            SCREEN_CENTER_X + right, SCREEN_CENTER_Y - forward, colorCyan);
 
 		vel_size /= 5;
+		if (vel_size > CG_WideX(SCREEN_WIDTH) / 2) {
+			vel_size = CG_WideX(SCREEN_WIDTH) / 2;
+		}
 		CG_DrawLine(SCREEN_CENTER_X, SCREEN_CENTER_Y,
 		            SCREEN_CENTER_X + vel_size * sin(vel_relang),
 		            SCREEN_CENTER_Y - vel_size * cos(vel_relang), colorRed);
-		if (vel_size > SCREEN_HEIGHT / 2) {
-			vel_size = SCREEN_HEIGHT / 2;
-		}
 		vel_size /= 2;
 		CG_DrawLine(SCREEN_CENTER_X, SCREEN_CENTER_Y,
 		            SCREEN_CENTER_X + vel_size * sin(vel_relang + per_angle),


### PR DESCRIPTION
While accelerating to high speeds, fps used to go down until exactly 83886088 ups where the game froze. This was caused by one line of the CGaz 2 HUD being drawn to coordinates way off the screen and thus making the game lag / freeze. Now moved the check whether the lines go off the screen or not to the correct place.