### PR TITLE
Moved snapping check to server

### DIFF
--- a/src/cgame/cg_timerun_draw.c
+++ b/src/cgame/cg_timerun_draw.c
@@ -710,7 +710,7 @@ void CG_DrawVelocitySnapping(void) {
 	int    fov       = 0;
 	int    i         = 0;
 
-	if (!cg_drawVelocitySnapping.integer || cg.isLogged || (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)) {
+	if (!cg_drawVelocitySnapping.integer || (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)) {
 		return;
 	}
 

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -973,8 +973,8 @@ void ClientThink_real(gentity_t *ent) {
 		SetTeam(ent, "s", -1, -1, qfalse);
 	}
 
-	// suburb, force snapping hud if disabled on server
-	if (g_disableSnappingHUD.integer != 0 && client->pers.snapping != 0) {
+	// suburb, force snapping hud if disabled on server or logged in
+	if ((g_disableSnappingHUD.integer != 0 || (client->sess.logged && (client->sess.sessionTeam == TEAM_AXIS || client->sess.sessionTeam == TEAM_ALLIES))) && client->pers.snapping != 0) {
 		CP(va("cpm \"%s^w: ^1You were removed from teams because you must use cg_drawVelocitySnapping 0.\n\"", GAME_VERSION_COLORED));
 		trap_SendServerCommand(ent - g_entities, "SnappingOff");
 		SetTeam(ent, "s", -1, -1, qfalse);


### PR DESCRIPTION
Moved snapping check to g_active because `cg.isLogged` turns false on vid_restart. Team checks are needed, otherwise it would break following someone while logged in and snapping HUD on.