### PR TITLE
Improve hideme and hideothers

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1175,14 +1175,10 @@ static void CG_DrawCrosshairNames(void) {
 		return;
 	}
 
-	// Nico, don't draw if hiding others is enabled and distance to the player is < cg_hideRange
-	if (cg_hideOthers.integer && clientNum != cg.clientNum) {
-		float dist;
-
-		dist = Distance((&cg_entities[cg.clientNum])->lerpOrigin, (&cg_entities[clientNum])->lerpOrigin);
-		if (dist < cg_hideRange.integer) {
-			return;
-		}
+	// Nico, don't draw if hiding others is enabled or distance to the player is < cg_hideRange
+	if (Distance((&cg_entities[cg.clientNum])->lerpOrigin, (&cg_entities[clientNum])->lerpOrigin) < cg_hideRange.integer || 
+		(clientNum != cg.clientNum && (cg_hideOthers.integer || cgs.clientinfo[clientNum].hideme))) {
+		return;
 	}
 
 	s = va("%s", cgs.clientinfo[clientNum].name);

--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -1247,6 +1247,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 	ci        = &cgs.clientinfo[clientNum];
 	character = CG_CharacterForClientinfo(ci, cent);
 
+	// suburb, if not following, it's not yourself making sounds and you want to hide others or others want to be hidden
+	if (!(cg.snap->ps.pm_flags & PMF_FOLLOW) && (ci->clientNum != cg.clientNum && (cg_hideOthers.integer || cgs.clientinfo[clientNum].hideme))) {
+		return; // mute others entirely
+	}
+
 	switch (event) {
 	//
 	// movement generated events

--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -1248,7 +1248,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 	character = CG_CharacterForClientinfo(ci, cent);
 
 	// suburb, if not following, it's not yourself making sounds and you want to hide others or others want to be hidden
-	if (!(cg.snap->ps.pm_flags & PMF_FOLLOW) && (ci->clientNum != cg.clientNum && (cg_hideOthers.integer || cgs.clientinfo[clientNum].hideme))) {
+	if (!(cg.snap->ps.pm_flags & PMF_FOLLOW) && (ci->clientNum != cg.clientNum && (etr_hideOthers.integer || cgs.clientinfo[clientNum].hideme))) {
 		return; // mute others entirely
 	}
 

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -1545,8 +1545,8 @@ void CG_Player(centity_t *cent) {
 		return;
 	}
 
-	// Nico, don't draw if hiding others is enabled and distance to the player is < cg_hideRange
-	if (cg_hideOthers.integer && ci->clientNum != cg.clientNum && Distance(cgsnap->lerpOrigin, cent->lerpOrigin) < cg_hideRange.integer) {
+	// Nico, don't draw if hiding others is enabled or distance to the player is < cg_hideRange
+	if ((cg_hideOthers.integer && ci->clientNum != cg.clientNum) || Distance(cgsnap->lerpOrigin, cent->lerpOrigin) < cg_hideRange.integer) {
 		return;
 	}
 


### PR DESCRIPTION
- Hiderange only takes effect when player doesn't want to hide others, thus other players are always hidden if hideothers is on
- Hidden players now don't make sounds anymore
- Hidden players can't be shot anymore
- Crosshairnames aren't shown while looking at hidden players anymore

Closes #165