### PR TITLE
feat: add /signin & /signout as alias for /login & /logout

### DIFF
--- a/docs/client_commands.md
+++ b/docs/client_commands.md
@@ -85,6 +85,14 @@ Attempt to login the player on timeruns.net API using `etr_authToken` value.
 
 Logout a player from timeruns.net API.
 
+# signin
+
+Alias for `/login`. Useful when running ET: Legacy where `login` is a reserved command.
+
+# signout
+
+Alias for `/logout`. Useful on ET: Legacy where `logout` is a reserved command.
+
 # m (private messaging)
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,19 +22,13 @@ The goal is to get from the start of the map to the end as fast as possible. The
 
 In order to permanently save records, you need to create an account on the official ETrun website, and link it to your game. Here is a step-by-step tutorial:
 
-* Go to the [website](https://timeruns.net/) and open the Signup tab.
-* Follow the instructions and wait for the account activation email.
-* Once your account has been activated, login on the ETrun [forum](https://forum.timeruns.net/).
-* In the top right corner, click on your nickname and follow this path:
-  * User Control Panel
-  * Profile
-  * Edit account settings
+* Go to the [website](https://timeruns.net/dashboard/register) and fill out the form.
 * Now you can see your Timeruns token. This is your password which links your game to your own website account. Never share it!
 * Copy your Timeruns token.
 * Insert your Timeruns token ingame into the `/etr_authToken` cvar.
-* Type `/login` into the console.
+* Type `/login` into the console (or `/signin` if you are using ET:Legacy).
 
-Congratulations! You are now logged in and able to set records. You cannow find your stats on the website and share them with your friends.
+Congratulations! You are now logged in and able to set records. You can now find your stats on the website and share them with your friends.
 
 ## Things to know
 
@@ -66,7 +60,7 @@ All HUD elements cvars accept float values to guarantee precise adjustments for 
 | etr_keysX | 553.2 |
 | etr_speedMeterY | 215.9 |
 
-Some HUD elements are meant to be aligned to the screen edge. Not to break compability with widescreens, those cvar values define an offset and thus are relative, in comparison to absolute coordinate cvars.
+Some HUD elements are meant to be aligned to the screen edge. Not to break compatibility with widescreens, those cvar values define an offset and thus are relative, in comparison to absolute coordinate cvars.
 
 | Cvar | Example Value |
 | ---- | ------------- |

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -641,17 +641,12 @@ static void CG_Tutorial_f(void) {
 	CG_Printf(va("account on ^fhttps://timeruns.net/^7, the official %s^7 website, and\n", GAME_VERSION_COLORED));
 	CG_Printf("link it to your game. Here is a step-by-step tutorial:\n");
 	CG_Printf("\n");
-	CG_Printf("^51. ^7Go to ^fhttps://timeruns.net/ ^7and open the Signup tab.\n");
-	CG_Printf("^52. ^7Follow the instructions and wait for the account activation email.\n");
-	CG_Printf(va("^53. ^7Once your account has been activated, login on the %s^7 forum,\n", GAME_VERSION_COLORED));
-	CG_Printf("   which is located here: ^fhttps://forum.timeruns.net/\n");
-	CG_Printf("^54. ^7In the top right corner, click on your nickname and follow this path:\n");
-	CG_Printf("   User Control Panel -> Profile -> Edit account settings\n");
-	CG_Printf("   Now you can see your Timeruns token. This is your password which\n");
+	CG_Printf("^51. ^7Go to ^fhttps://timeruns.net/dashboard/register ^7and fill out the form.\n");
+	CG_Printf("^52. ^7Now you can see your Timeruns token. This is your password which\n");
 	CG_Printf("   links your game to your own website account. Never share it!\n");
-	CG_Printf("^55. ^7Copy your Timeruns token.\n");
-	CG_Printf("^56. ^7Insert your Timeruns token ingame into the ^n/etr_authToken ^7cvar.\n");
-	CG_Printf("^57. ^7Type ^n/login ^7into the console.\n");
+	CG_Printf("^53. ^7Copy your Timeruns token.\n");
+	CG_Printf("^54. ^7Insert your Timeruns token ingame into the ^n/etr_authToken ^7cvar.\n");
+	CG_Printf("^55. ^7Type ^n/login ^7into the console (^n/signin^7 if you're using ET:Legacy).\n");
 	CG_Printf("\n");
 	CG_Printf("Congratulations! You are now logged in and able to set records. You can\n");
 	CG_Printf(va("now find your stats on the %s^7 website and share them with your friends.\n", GAME_VERSION_COLORED));
@@ -827,6 +822,8 @@ void CG_InitConsoleCommands(void) {
 	// Nico, login/logout
 	trap_AddCommand("login");
 	trap_AddCommand("logout");
+	trap_AddCommand("signin");
+	trap_AddCommand("signout");
 
 	// Nico, records & rank
 	trap_AddCommand("records");

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2267,6 +2267,8 @@ static command_t floodProtectedCommands[] =
 	// ETrun specific commands
 	{ "login",           qtrue,  Cmd_Login_f,           qtrue,  "Allows you to login via timeruns.net",     NULL                                           },
 	{ "logout",          qtrue,  Cmd_Logout_f,          qtrue,  "Allows you to logout",                     NULL                                           },
+	{ "signin",          qtrue,  Cmd_Login_f,           qtrue,  "Alias for /login, allows to login via timeruns.net",     NULL                                           },
+	{ "signout",         qtrue,  Cmd_Logout_f,          qtrue,  "Alias for /logout, allows you to logout",                     NULL                                           },
 	{ "records",         qtrue,  Cmd_Records_f,         qtrue,  "Displays current map #1 records",          NULL                                           },
 	{ "rank",            qtrue,  Cmd_Rank_f,            qtrue,  "Shows rankings for given options",         "[userName] [mapName] [runName] [physicsName]" },
 	{ "loadCheckpoints", qtrue,  Cmd_LoadCheckpoints_f, qtrue,  "Loads checkpoints from your PB",           "[userName] [run name or id]"                  },


### PR DESCRIPTION
Add `/signin` & `/signout` aliases of `/login` & `/logout` to be used in ET: Legacy.
These are required because ET: Legacy has added their own `/login` & `/logout` commands.